### PR TITLE
articles/django-rest-framework-models.mdにおいて、表が壊れていたので修正

### DIFF
--- a/articles/django-rest-framework-models.md
+++ b/articles/django-rest-framework-models.md
@@ -14,24 +14,24 @@ published: true # 公開設定（falseにすると下書き）
 
 ## Field(フィールド)一覧
 
-| Field の種類            | フィールドの説明                                         |
+| Field の種類            | フィールドの説明                                         | 備考 |
 | ----------------------- | -------------------------------------------------------- | ------------------ |
-| `BooleanField`          | boolean 値 (True/False)                                  |
-| `CharField`             | 文字列                                                   |
+| `BooleanField`          | boolean 値 (True/False)                                  | |
+| `CharField`             | 文字列                                                   | |
 | `TextField`             | 長い文字列（テキスト）                                   | `max_length`が必須 |
-| `SlugField`             | 文字列(アルファベット、数字、アンダーバー、ハイフンのみ) |
-| `JSONField`             | JSON エンコードされたデータ                              |
-| `IntegerField`          | 整数                                                     |
-| `FloatField`            | 浮動小数点数                                             |
-| `PositiveIntegerField`  | 0 または正の整数                                         |
-| `DateTimeField`         | 日付と時刻                                               |
-| `DateField`             | 日付                                                     |
-| `TimeField`             | 時刻                                                     |
-| `EmailField`            | メールアドレス                                           |
-| `URLField`              | URL                                                      |
-| `FileField`             | ファイル                                                 |
-| `ImageField`            | 画像ファイル                                             |
-| `GenericIPAddressField` | IP アドレス                                              |
+| `SlugField`             | 文字列(アルファベット、数字、アンダーバー、ハイフンのみ) | |
+| `JSONField`             | JSON エンコードされたデータ                              | |
+| `IntegerField`          | 整数                                                     | |
+| `FloatField`            | 浮動小数点数                                             | |
+| `PositiveIntegerField`  | 0 または正の整数                                         | |
+| `DateTimeField`         | 日付と時刻                                               | |
+| `DateField`             | 日付                                                     | |
+| `TimeField`             | 時刻                                                     | |
+| `EmailField`            | メールアドレス                                           | |
+| `URLField`              | URL                                                      | |
+| `FileField`             | ファイル                                                 | |
+| `ImageField`            | 画像ファイル                                             | |
+| `GenericIPAddressField` | IP アドレス                                              | |
 
 ## Field 詳細
 


### PR DESCRIPTION
[[Django] modelsのField一覧](https://zenn.dev/aew2sbee/articles/django-rest-framework-models)において、markdownのテーブルがうまく表示されていなかったので修正しました。
一部推測で「備考」と追加させていただきましたが、ご意向と異なる場合は変更していただいて構いません。

よろしくお願いします。